### PR TITLE
Implement OpenAI rewriting for story generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ This project automates fetching StudyRiver articles, generating stories in three
 - `PB_SFTP_KEY` - SSH private key for SFTP.
 - `NEWS_API_KEY` - optional; not required when fetching public WordPress articles.
 
+## Story Generation
+Set the `OPENAI_API_KEY` environment variable before running `scripts/generate_story.py`.
+The script now sends each article's title and content to the OpenAI ChatGPT API
+(model defined by `OPENAI_MODEL`, default `gpt-3.5-turbo`) and writes the
+rewritten story into `stories/ja/<level>/`.
+
 ## Workflows
 1. **daily_fetch** (`21:00 JST`)
    - Fetch public articles from StudyRiver using the WordPress REST API.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 paramiko
+openai

--- a/scripts/generate_story.py
+++ b/scripts/generate_story.py
@@ -2,6 +2,9 @@ import os
 import json
 import glob
 import argparse
+from typing import List
+
+import openai
 
 
 def load_articles():
@@ -10,6 +13,30 @@ def load_articles():
         raise FileNotFoundError('No data files found')
     with open(files[-1], 'r', encoding='utf-8') as f:
         return json.load(f)
+
+
+def rewrite_article(title: str, body: str, level: str) -> str:
+    """Rewrite article content for the given reading level using OpenAI."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("OPENAI_API_KEY not set")
+    openai.api_key = api_key
+
+    model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+    level_str = level.upper()
+    prompt = (
+        f"You are a helpful assistant who rewrites Japanese articles for "
+        f"reading level {level_str}. Summarize or rewrite the following text "
+        f"in Japanese so it is appropriate for that level.\n\nTitle: {title}\n\n{body}"
+    )
+    messages: List[dict] = [
+        {"role": "user", "content": prompt}
+    ]
+    resp = openai.ChatCompletion.create(
+        model=model,
+        messages=messages,
+    )
+    return resp["choices"][0]["message"]["content"].strip()
 
 
 def main():
@@ -26,8 +53,9 @@ def main():
         out_dir = os.path.join('stories', 'ja', args.level, f'vol{ym}')
         os.makedirs(out_dir, exist_ok=True)
         path = os.path.join(out_dir, f'{i:02d}.md')
+        story = rewrite_article(title, body, args.level)
         with open(path, 'w', encoding='utf-8') as f:
-            f.write(f"# {title}\n\n{body}\n")
+            f.write(f"# {title}\n\n{story}\n")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- update `generate_story.py` to rewrite articles using the OpenAI API
- add `openai` dependency
- explain new story generation behaviour in README

## Testing
- `python -m py_compile scripts/generate_story.py`


------
https://chatgpt.com/codex/tasks/task_e_68524aa1d370832186c69aca2980808e